### PR TITLE
feat(assets): Add Support for Electrical Component Connections

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Run nox
-        uses: frequenz-floss/gh-action-nox@v1.0.0
+        uses: frequenz-floss/gh-action-nox@v1.0.1
         with:
           python-version: "3.11"
           nox-session: ci_checks_max
@@ -35,7 +35,7 @@ jobs:
           submodules: true
 
       - name: Setup Python
-        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.0
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.1
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           dependencies: .[dev-mkdocs]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
         # only use hashes to pick the action to execute (instead of tags or branches).
         # For more details read:
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # 5.0.0
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # 6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           dot: true

--- a/src/frequenz/client/assets/__init__.py
+++ b/src/frequenz/client/assets/__init__.py
@@ -5,6 +5,7 @@
 
 from ._client import AssetsApiClient
 from ._delivery_area import DeliveryArea, EnergyMarketCodeType
+from ._lifetime import Lifetime
 from ._location import Location
 from ._microgrid import Microgrid, MicrogridStatus
 
@@ -15,4 +16,5 @@ __all__ = [
     "Microgrid",
     "MicrogridStatus",
     "Location",
+    "Lifetime",
 ]

--- a/src/frequenz/client/assets/_client.py
+++ b/src/frequenz/client/assets/_client.py
@@ -9,6 +9,8 @@ This module provides a client for the Assets API.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from frequenz.api.assets.v1 import assets_pb2, assets_pb2_grpc
 from frequenz.client.base import channel
 from frequenz.client.base.client import BaseApiClient, call_stub_method
@@ -141,8 +143,8 @@ class AssetsApiClient(
     async def list_microgrid_electrical_component_connections(
         self,
         microgrid_id: int,
-        source_component_ids: list[int] | None = None,
-        destination_component_ids: list[int] | None = None,
+        source_component_ids: Iterable[int] = (),
+        destination_component_ids: Iterable[int] = (),
     ) -> list[ComponentConnection | None]:
         """
         Get the electrical component connections of a microgrid.
@@ -160,13 +162,9 @@ class AssetsApiClient(
         """
         request = assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
             microgrid_id=microgrid_id,
+            source_component_ids=source_component_ids,
+            destination_component_ids=destination_component_ids,
         )
-
-        if source_component_ids:
-            request.source_component_ids.extend(source_component_ids)
-
-        if destination_component_ids:
-            request.destination_component_ids.extend(destination_component_ids)
 
         response = await call_stub_method(
             self,

--- a/src/frequenz/client/assets/_client.py
+++ b/src/frequenz/client/assets/_client.py
@@ -175,7 +175,9 @@ class AssetsApiClient(
             method_name="ListMicrogridElectricalComponentConnections",
         )
 
-        return [
-            component_connection_from_proto(connection)
-            for connection in response.connections
-        ]
+        return list(
+            map(
+                component_connection_from_proto,
+                filter(bool, response.connections),
+            )
+        )

--- a/src/frequenz/client/assets/_client.py
+++ b/src/frequenz/client/assets/_client.py
@@ -13,12 +13,11 @@ from frequenz.api.assets.v1 import assets_pb2, assets_pb2_grpc
 from frequenz.client.base import channel
 from frequenz.client.base.client import BaseApiClient, call_stub_method
 
-from frequenz.client.assets.electrical_component._electrical_component import (
-    ElectricalComponent,
-)
-
 from ._microgrid import Microgrid
 from ._microgrid_proto import microgrid_from_proto
+from .electrical_component._connection import ComponentConnection
+from .electrical_component._connection_proto import component_connection_from_proto
+from .electrical_component._electrical_component import ElectricalComponent
 from .electrical_component._electrical_component_proto import electrical_component_proto
 from .exceptions import ClientNotConnected
 
@@ -137,4 +136,48 @@ class AssetsApiClient(
 
         return [
             electrical_component_proto(component) for component in response.components
+        ]
+
+    async def list_microgrid_electrical_component_connections(
+        self,
+        microgrid_id: int,
+        source_component_ids: list[int] | None = None,
+        destination_component_ids: list[int] | None = None,
+    ) -> list[ComponentConnection | None]:
+        """
+        Get the electrical component connections of a microgrid.
+
+        Args:
+            microgrid_id: The ID of the microgrid to get the electrical
+                component connections of.
+            source_component_ids: Only return connections that originate from
+                these component IDs. If None or empty, no filtering is applied.
+            destination_component_ids: Only return connections that terminate at
+                these component IDs. If None or empty, no filtering is applied.
+
+        Returns:
+            The electrical component connections of the microgrid.
+        """
+        request = assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
+            microgrid_id=microgrid_id,
+        )
+
+        if source_component_ids:
+            request.source_component_ids.extend(source_component_ids)
+
+        if destination_component_ids:
+            request.destination_component_ids.extend(destination_component_ids)
+
+        response = await call_stub_method(
+            self,
+            lambda: self.stub.ListMicrogridElectricalComponentConnections(
+                request,
+                timeout=DEFAULT_GRPC_CALL_TIMEOUT,
+            ),
+            method_name="ListMicrogridElectricalComponentConnections",
+        )
+
+        return [
+            component_connection_from_proto(connection)
+            for connection in response.connections
         ]

--- a/src/frequenz/client/assets/_lifetime.py
+++ b/src/frequenz/client/assets/_lifetime.py
@@ -13,7 +13,7 @@ class Lifetime:
     """An active operational period of a microgrid asset.
 
     Warning:
-        The [`end`][frequenz.client.microgrid.Lifetime.end] timestamp indicates that the
+        The [`end`][frequenz.client.assets.Lifetime.end] timestamp indicates that the
         asset has been permanently removed from the system.
     """
 
@@ -21,7 +21,7 @@ class Lifetime:
     """The moment when the asset became operationally active.
 
     If `None`, the asset is considered to be active in any past moment previous to the
-    [`end`][frequenz.client.microgrid.Lifetime.end].
+    [`end`][frequenz.client.assets.Lifetime.end].
     """
 
     end: datetime | None = None

--- a/src/frequenz/client/assets/cli/__main__.py
+++ b/src/frequenz/client/assets/cli/__main__.py
@@ -274,14 +274,8 @@ async def list_microgrid_electrical_component_connections(
         component_connections = (
             await client.list_microgrid_electrical_component_connections(
                 microgrid_id,
-                source_component_ids=(
-                    list(source_component_ids) if source_component_ids else None
-                ),
-                destination_component_ids=(
-                    list(destination_component_ids)
-                    if destination_component_ids
-                    else None
-                ),
+                source_component_ids=source_component_ids,
+                destination_component_ids=destination_component_ids,
             )
         )
         print_component_connections(component_connections)

--- a/src/frequenz/client/assets/cli/__main__.py
+++ b/src/frequenz/client/assets/cli/__main__.py
@@ -40,7 +40,11 @@ import asyncclick as click
 from frequenz.client.assets._client import AssetsApiClient
 from frequenz.client.assets.exceptions import ApiClientError
 
-from ._utils import print_electrical_components, print_microgrid_details
+from ._utils import (
+    print_component_connections,
+    print_electrical_components,
+    print_microgrid_details,
+)
 
 
 @click.group(invoke_without_command=True)
@@ -190,6 +194,97 @@ async def list_microgrid_electrical_components(
             microgrid_id
         )
         print_electrical_components(electrical_components)
+    except ApiClientError as e:
+        error_dict = {
+            "error_type": type(e).__name__,
+            "server_url": e.server_url,
+            "operation": e.operation,
+            "description": e.description,
+        }
+        click.echo(json.dumps(error_dict, indent=2))
+        raise click.Abort()
+
+
+@cli.command("component-connections")
+@click.pass_context
+@click.argument("microgrid-id", required=True, type=int)
+@click.option(
+    "--source",
+    "source_component_ids",
+    help="Filter connections by source component ID(s). Can be specified multiple times.",
+    type=int,
+    multiple=True,
+    required=False,
+)
+@click.option(
+    "--destination",
+    "destination_component_ids",
+    help="Filter connections by destination component ID(s). Can be specified multiple times.",
+    type=int,
+    multiple=True,
+    required=False,
+)
+async def list_microgrid_electrical_component_connections(
+    ctx: click.Context,
+    microgrid_id: int,
+    source_component_ids: tuple[int, ...],
+    destination_component_ids: tuple[int, ...],
+) -> None:
+    """
+    Get and display electrical component connections by microgrid ID.
+
+    This command fetches detailed information about all electrical component connections
+    in a specific microgrid from the Assets API and displays it in JSON format.
+    The output can be piped to other tools for further processing.
+
+    Args:
+        ctx: Click context object containing the initialized API client.
+        microgrid_id: The unique identifier of the microgrid to retrieve.
+        source_component_ids: Optional filter for connections from specific
+            source component IDs.
+        destination_component_ids: Optional filter for connections to specific
+            destination component IDs.
+
+    Raises:
+        click.Abort: If there is an error printing the electrical component connections.
+
+    Example:
+        ```bash
+        # Get all connections for microgrid with ID 123
+        assets-cli component-connections 123
+
+        # Filter by source component
+        assets-cli component-connections 123 --source 5
+
+        # Filter by destination component
+        assets-cli component-connections 123 --destination 10
+
+        # Filter by both source and destination
+        assets-cli component-connections 123 --source 5 --destination 10
+
+        # Filter by multiple source components
+        assets-cli component-connections 123 --source 5 --source 6 --source 7
+
+        # Pipe output to jq for filtering
+        assets-cli component-connections 123 | jq ".[]"
+        ```
+    """
+    try:
+        client = ctx.obj["client"]
+        component_connections = (
+            await client.list_microgrid_electrical_component_connections(
+                microgrid_id,
+                source_component_ids=(
+                    list(source_component_ids) if source_component_ids else None
+                ),
+                destination_component_ids=(
+                    list(destination_component_ids)
+                    if destination_component_ids
+                    else None
+                ),
+            )
+        )
+        print_component_connections(component_connections)
     except ApiClientError as e:
         error_dict = {
             "error_type": type(e).__name__,

--- a/src/frequenz/client/assets/cli/_utils.py
+++ b/src/frequenz/client/assets/cli/_utils.py
@@ -4,6 +4,10 @@ import asyncclick as click
 
 from frequenz.client.assets._microgrid import Microgrid
 from frequenz.client.assets._microgrid_json import microgrid_to_json
+from frequenz.client.assets.electrical_component._connection import ComponentConnection
+from frequenz.client.assets.electrical_component._connection_json import (
+    component_connections_to_json,
+)
 from frequenz.client.assets.electrical_component._electrical_component import (
     ElectricalComponent,
 )
@@ -42,3 +46,17 @@ def print_electrical_components(
         electrical_components: The list of ElectricalComponent instances to print to console.
     """
     click.echo(electrical_components_to_json(electrical_components))
+
+
+def print_component_connections(
+    component_connections: list[ComponentConnection],
+) -> None:
+    """
+    Print electrical component connections to console in JSON format using custom encoder.
+
+    This function converts the ComponentConnection instances to JSON using a custom
+    encoder and outputs it as formatted JSON to the console. The output is
+    designed to be machine-readable and can be piped to tools like jq for
+    further processing.
+    """
+    click.echo(component_connections_to_json(component_connections))

--- a/src/frequenz/client/assets/electrical_component/__init__.py
+++ b/src/frequenz/client/assets/electrical_component/__init__.py
@@ -14,6 +14,7 @@ from ._breaker import Breaker
 from ._capacitor_bank import CapacitorBank
 from ._category import ElectricalComponentCategory
 from ._chp import Chp
+from ._connection import ComponentConnection
 from ._converter import Converter
 from ._crypto_miner import CryptoMiner
 from ._electrical_component import ElectricalComponent
@@ -87,4 +88,5 @@ __all__ = [
     "StaticTransferSwitch",
     "UninterruptiblePowerSupply",
     "WindTurbine",
+    "ComponentConnection",
 ]

--- a/src/frequenz/client/assets/electrical_component/_connection.py
+++ b/src/frequenz/client/assets/electrical_component/_connection.py
@@ -1,0 +1,72 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Component connection."""
+
+import dataclasses
+from datetime import datetime, timezone
+
+from frequenz.client.common.microgrid.components import ComponentId
+
+from .._lifetime import Lifetime
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ComponentConnection:
+    """A single electrical link between two components within a microgrid.
+
+    A component connection represents the physical wiring as viewed from the grid
+    connection point, if one exists, or from the islanding point, in case of an islanded
+    microgrids.
+
+    Note: Physical Representation
+        This object is not about data flow but rather about the physical
+        electrical connections between components. Therefore, the IDs for the
+        source and destination components correspond to the actual setup within
+        the microgrid.
+
+    Note: Direction
+        The direction of the connection follows the flow of current away from the
+        grid connection point, or in case of islands, away from the islanding
+        point. This direction is aligned with positive current according to the
+        [Passive Sign Convention]
+        (https://en.wikipedia.org/wiki/Passive_sign_convention).
+
+    Note: Historical Data
+        The timestamps of when a connection was created and terminated allow for
+        tracking the changes over time to a microgrid, providing insights into
+        when and how the microgrid infrastructure has been modified.
+    """
+
+    source: ComponentId
+    """The unique identifier of the component where the connection originates.
+
+    This is aligned with the direction of current flow away from the grid connection
+    point, or in case of islands, away from the islanding point.
+    """
+
+    destination: ComponentId
+    """The unique ID of the component where the connection terminates.
+
+    This is the component towards which the current flows.
+    """
+
+    operational_lifetime: Lifetime = dataclasses.field(default_factory=Lifetime)
+    """The operational lifetime of the connection."""
+
+    def __post_init__(self) -> None:
+        """Ensure that the source and destination components are different."""
+        if self.source == self.destination:
+            raise ValueError("Source and destination components must be different")
+
+    def is_operational_at(self, timestamp: datetime) -> bool:
+        """Check whether this connection is operational at a specific timestamp."""
+        return self.operational_lifetime.is_operational_at(timestamp)
+
+    def is_operational_now(self) -> bool:
+        """Whether this connection is currently operational."""
+        return self.is_operational_at(datetime.now(timezone.utc))
+
+    def __str__(self) -> str:
+        """Return a human-readable string representation of this instance."""
+        return f"{self.source}->{self.destination}"

--- a/src/frequenz/client/assets/electrical_component/_connection_json.py
+++ b/src/frequenz/client/assets/electrical_component/_connection_json.py
@@ -1,0 +1,21 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""JSON encoder for ComponentConnection objects."""
+
+import json
+from dataclasses import asdict
+
+from .._utils import AssetsJSONEncoder
+from ._connection import ComponentConnection
+
+
+def component_connections_to_json(
+    component_connections: list[ComponentConnection],
+) -> str:
+    """Convert a list of ElectricalComponent objects to a JSON string."""
+    return json.dumps(
+        [asdict(connection) for connection in component_connections],
+        cls=AssetsJSONEncoder,
+        indent=2,
+    )

--- a/src/frequenz/client/assets/electrical_component/_connection_proto.py
+++ b/src/frequenz/client/assets/electrical_component/_connection_proto.py
@@ -1,0 +1,106 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Loading of ComponentConnection objects from protobuf messages."""
+
+import logging
+
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+from frequenz.client.common.microgrid.components import ComponentId
+
+from .._lifetime import Lifetime
+from .._lifetime_proto import lifetime_from_proto
+from ._connection import ComponentConnection
+
+_logger = logging.getLogger(__name__)
+
+
+def component_connection_from_proto(
+    message: electrical_components_pb2.ElectricalComponentConnection,
+) -> ComponentConnection | None:
+    """Create a `ComponentConnection` from a protobuf message."""
+    major_issues: list[str] = []
+    minor_issues: list[str] = []
+
+    connection = component_connection_from_proto_with_issues(
+        message, major_issues=major_issues, minor_issues=minor_issues
+    )
+
+    if major_issues:
+        _logger.warning(
+            "Found issues in component connection: %s | Protobuf message:\n%s",
+            ", ".join(major_issues),
+            message,
+        )
+    if minor_issues:
+        _logger.debug(
+            "Found minor issues in component connection: %s | Protobuf message:\n%s",
+            ", ".join(minor_issues),
+            message,
+        )
+
+    return connection
+
+
+def component_connection_from_proto_with_issues(
+    message: electrical_components_pb2.ElectricalComponentConnection,
+    *,
+    major_issues: list[str],
+    minor_issues: list[str],
+) -> ComponentConnection | None:
+    """Create a `ComponentConnection` from a protobuf message collecting issues.
+
+    This function is useful when you want to collect issues during the parsing
+    of multiple connections, rather than logging them immediately.
+
+    Args:
+        message: The protobuf message to parse.
+        major_issues: A list to collect major issues found during parsing.
+        minor_issues: A list to collect minor issues found during parsing.
+
+    Returns:
+        A `ComponentConnection` object created from the protobuf message, or
+            `None` if the protobuf message is completely invalid and a
+            `ComponentConnection` cannot be created.
+    """
+    source_component_id = ComponentId(message.source_electrical_component_id)
+    destination_component_id = ComponentId(message.destination_electrical_component_id)
+    if source_component_id == destination_component_id:
+        major_issues.append(
+            f"connection ignored: source and destination are the same ({source_component_id})",
+        )
+        return None
+
+    lifetime = _get_operational_lifetime_from_proto(
+        message, major_issues=major_issues, minor_issues=minor_issues
+    )
+
+    return ComponentConnection(
+        source=source_component_id,
+        destination=destination_component_id,
+        operational_lifetime=lifetime,
+    )
+
+
+def _get_operational_lifetime_from_proto(
+    message: electrical_components_pb2.ElectricalComponentConnection,
+    *,
+    major_issues: list[str],
+    minor_issues: list[str],
+) -> Lifetime:
+    """Get the operational lifetime from a protobuf message."""
+    if message.HasField("operational_lifetime"):
+        try:
+            return lifetime_from_proto(message.operational_lifetime)
+        except ValueError as exc:
+            major_issues.append(
+                f"invalid operational lifetime ({exc}), considering it as missing "
+                "(i.e. always operational)",
+            )
+    else:
+        minor_issues.append(
+            "missing operational lifetime, considering it always operational",
+        )
+    return Lifetime()

--- a/src/frequenz/client/assets/electrical_component/_connection_proto.py
+++ b/src/frequenz/client/assets/electrical_component/_connection_proto.py
@@ -25,7 +25,7 @@ def component_connection_from_proto(
     minor_issues: list[str] = []
 
     connection = component_connection_from_proto_with_issues(
-        message, major_issues=major_issues, minor_issues=minor_issues
+        message, major_issues=major_issues
     )
 
     if major_issues:
@@ -48,7 +48,6 @@ def component_connection_from_proto_with_issues(
     message: electrical_components_pb2.ElectricalComponentConnection,
     *,
     major_issues: list[str],
-    minor_issues: list[str],
 ) -> ComponentConnection | None:
     """Create a `ComponentConnection` from a protobuf message collecting issues.
 
@@ -58,7 +57,6 @@ def component_connection_from_proto_with_issues(
     Args:
         message: The protobuf message to parse.
         major_issues: A list to collect major issues found during parsing.
-        minor_issues: A list to collect minor issues found during parsing.
 
     Returns:
         A `ComponentConnection` object created from the protobuf message, or
@@ -73,9 +71,11 @@ def component_connection_from_proto_with_issues(
         )
         return None
 
-    lifetime = _get_operational_lifetime_from_proto(
-        message, major_issues=major_issues, minor_issues=minor_issues
-    )
+    try:
+        lifetime = _get_operational_lifetime_from_proto(message)
+    except ValueError as exc:
+        major_issues.append(f"connection ignored: invalid operational lifetime ({exc})")
+        return None
 
     return ComponentConnection(
         source=source_component_id,
@@ -86,21 +86,8 @@ def component_connection_from_proto_with_issues(
 
 def _get_operational_lifetime_from_proto(
     message: electrical_components_pb2.ElectricalComponentConnection,
-    *,
-    major_issues: list[str],
-    minor_issues: list[str],
 ) -> Lifetime:
     """Get the operational lifetime from a protobuf message."""
     if message.HasField("operational_lifetime"):
-        try:
-            return lifetime_from_proto(message.operational_lifetime)
-        except ValueError as exc:
-            major_issues.append(
-                f"invalid operational lifetime ({exc}), considering it as missing "
-                "(i.e. always operational)",
-            )
-    else:
-        minor_issues.append(
-            "missing operational lifetime, considering it always operational",
-        )
+        return lifetime_from_proto(message.operational_lifetime)
     return Lifetime()

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/empty_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/empty_case.py
@@ -1,0 +1,31 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Test list_connections with no connections: result should be empty."""
+
+from typing import Any
+
+from frequenz.api.assets.v1 import assets_pb2
+
+# No client_args or client_kwargs needed for this call
+
+
+def assert_stub_method_call(stub_method: Any) -> None:
+    """Assert that the gRPC request matches the expected request."""
+    stub_method.assert_called_once_with(
+        assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
+            microgrid_id=1234, source_component_ids=[], destination_component_ids=[]
+        ),
+        timeout=60.0,
+    )
+
+
+client_args = (1234,)
+grpc_response = assets_pb2.ListMicrogridElectricalComponentConnectionsResponse(
+    connections=[]
+)
+
+
+def assert_client_result(result: Any) -> None:  # noqa: D103
+    """Assert that the client result is an empty list."""
+    assert not list(result)

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/error_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/error_case.py
@@ -1,0 +1,32 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Test list_electrical_components with error."""
+
+from typing import Any
+
+from frequenz.api.assets.v1 import assets_pb2
+from grpc import StatusCode
+
+from frequenz.client.assets.exceptions import PermissionDenied
+from tests.util import make_grpc_error
+
+
+def assert_stub_method_call(stub_method: Any) -> None:
+    """Assert that the gRPC request matches the expected request."""
+    stub_method.assert_called_once_with(
+        assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
+            microgrid_id=1234
+        ),
+        timeout=60.0,
+    )
+
+
+client_args = (1234,)
+grpc_response = make_grpc_error(StatusCode.PERMISSION_DENIED)
+
+
+def assert_client_exception(exception: Exception) -> None:
+    """Assert that the client exception matches the expected error."""
+    assert isinstance(exception, PermissionDenied)
+    assert exception.grpc_error == grpc_response

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/success_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/success_case.py
@@ -1,0 +1,61 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Test data for successful connection listing."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.common.v1alpha8.microgrid import lifetime_pb2
+from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
+    electrical_components_pb2,
+)
+from frequenz.client.base.conversion import to_timestamp
+from frequenz.client.common.microgrid.components import ComponentId
+
+from frequenz.client.assets import Lifetime
+from frequenz.client.assets.electrical_component import ComponentConnection
+
+
+def assert_stub_method_call(stub_method: Any) -> None:
+    """Assert that the gRPC request matches the expected request."""
+    stub_method.assert_called_once_with(
+        assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
+            microgrid_id=1234, source_component_ids=[], destination_component_ids=[]
+        ),
+        timeout=60.0,
+    )
+
+
+client_args = (1234,)
+lifetime_start = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+grpc_response = assets_pb2.ListMicrogridElectricalComponentConnectionsResponse(
+    connections=[
+        electrical_components_pb2.ElectricalComponentConnection(
+            source_electrical_component_id=1, destination_electrical_component_id=2
+        ),
+        electrical_components_pb2.ElectricalComponentConnection(
+            source_electrical_component_id=2,
+            destination_electrical_component_id=3,
+            operational_lifetime=lifetime_pb2.Lifetime(
+                start_timestamp=to_timestamp(lifetime_start)
+            ),
+        ),
+    ]
+)
+
+
+def assert_client_result(actual_result: Any) -> None:
+    """Assert that the client result matches the expected connections list."""
+    assert list(actual_result) == [
+        ComponentConnection(
+            source=ComponentId(1),
+            destination=ComponentId(2),
+        ),
+        ComponentConnection(
+            source=ComponentId(2),
+            destination=ComponentId(3),
+            operational_lifetime=Lifetime(start=lifetime_start),
+        ),
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,3 +50,20 @@ async def test_list_microgrid_electrical_components(
 ) -> None:
     """Test list_microgrid_electrical_components method."""
     await spec.test_unary_unary_call(client, "ListMicrogridElectricalComponents")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "spec",
+    get_test_specs(
+        "list_microgrid_electrical_component_connections", tests_dir=TESTS_DIR
+    ),
+    ids=str,
+)
+async def test_list_connections(
+    client: AssetsApiClient, spec: ApiClientTestCaseSpec
+) -> None:
+    """Test list_connections method."""
+    await spec.test_unary_unary_call(
+        client, "ListMicrogridElectricalComponentConnections"
+    )


### PR DESCRIPTION
### Summary
Add a new client method to retrieve microgrid electrical components connections. For this a new ComponentConnection class is introduced. The CLI is also extended to add a command to list component-connections, for example: `assets-cli component-connections 123 --source 5 --source 6 --destination 10`



#### Resources
- [https://github.com/frequenz-floss/frequenz-client-microgrid-python/blob/v0.18.x/src/frequenz/client/microgrid/component/_connection.py](https://github.com/frequenz-floss/frequenz-client-microgrid-python/blob/v0.18.x/src/frequenz/client/microgrid/component/_connection.py)