### PR TITLE
Merge tag v0.1.0 into v0.x.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,31 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release updates the `frequenz-api-assets` dependency to use a version range instead of a specific Git reference, providing more flexibility for dependency updates while maintaining compatibility.
 
-## Upgrading
+## Changes
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+### Dependency Updates
 
-## New Features
+* **Updated `frequenz-api-assets` dependency**:
+  * Changed from Git reference (`@ git+https://github.com/frequenz-floss/frequenz-api-assets.git@v0.x.x`) to version range (`>= 0.1.0, < 0.2.0`)
+  * Enables automatic updates within the specified version range
+  * Maintains backward compatibility while reducing maintenance overhead
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+## Benefits
 
-## Bug Fixes
+* **Improved dependency management**: Version ranges allow for automatic updates within the specified range
+* **Better compatibility**: Ensures compatibility with the project while allowing for patch and minor version updates
+* **Reduced maintenance overhead**: Eliminates the need to manually update Git references for compatible versions
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+## Migration Notes
+
+No migration required. This is a transparent dependency update that maintains full backward compatibility.
+
+## Files Changed
+
+* `pyproject.toml`: Updated the `frequenz-api-assets` dependency specification
+
+## Type of Change
+
+* [x] Dependency update

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,31 +2,20 @@
 
 ## Summary
 
-This release updates the `frequenz-api-assets` dependency to use a version range instead of a specific Git reference, providing more flexibility for dependency updates while maintaining compatibility.
+This release adds support for retrieving microgrid electrical component connections through a new client method and CLI command.
 
-## Changes
+## Upgrading
 
-### Dependency Updates
+No migration required. This is a backward-compatible feature addition.
 
-* **Updated `frequenz-api-assets` dependency**:
-  * Changed from Git reference (`@ git+https://github.com/frequenz-floss/frequenz-api-assets.git@v0.x.x`) to version range (`>= 0.1.0, < 0.2.0`)
-  * Enables automatic updates within the specified version range
-  * Maintains backward compatibility while reducing maintenance overhead
+## New Features
 
-## Benefits
+### Component Connections API
 
-* **Improved dependency management**: Version ranges allow for automatic updates within the specified range
-* **Better compatibility**: Ensures compatibility with the project while allowing for patch and minor version updates
-* **Reduced maintenance overhead**: Eliminates the need to manually update Git references for compatible versions
+* **New `ComponentConnection` class**: Introduced to represent connections between electrical components in a microgrid
+* **New client method**: Added method to retrieve microgrid electrical component connections
+* **CLI command extension**: Added `component-connections` command to list component connections
 
-## Migration Notes
+## Bug Fixes
 
-No migration required. This is a transparent dependency update that maintains full backward compatibility.
-
-## Files Changed
-
-* `pyproject.toml`: Updated the `frequenz-api-assets` dependency specification
-
-## Type of Change
-
-* [x] Dependency update
+<!-- No bug fixes in this release -->


### PR DESCRIPTION
This is a PR with just the tag v0.1.0 as head. After this is merged, the tag v0.1.0 will be shown when looking at the history of the v0.x.x branch, making it more obvious that the branch is on top of the existing tag.
