### PR TITLE
chore: bump frequenz-api-assets to 0.3.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,9 @@
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
+* Updated `frequenz-api-assets` to `0.3.0`, replacing the old `assets.v1`
+  generated API with `platformassets.v1alpha1`.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.13.0, < 5",
-  "frequenz-api-assets >= 0.1.0, < 0.3.0",
-  "frequenz-api-common >= 0.8.2, < 1",
+  "frequenz-api-assets >= 0.3.0, < 0.4.0",
+  "frequenz-api-common >= 0.8.9, < 1",
   "frequenz-client-base >= 0.11.0, < 0.12.0",
   "frequenz-client-common >= 0.3.6, < 0.4.0",
-  "grpcio >= 1.73.1, < 2",
+  "grpcio >= 1.80.0, < 2",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/client/assets/_client.py
+++ b/src/frequenz/client/assets/_client.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from frequenz.api.assets.v1 import assets_pb2, assets_pb2_grpc
+from frequenz.api.platformassets.v1alpha1 import (
+    platformassets_pb2,
+    platformassets_pb2_grpc,
+)
 from frequenz.client.base import channel
 from frequenz.client.base.client import BaseApiClient, call_stub_method
 from frequenz.client.common.microgrid import MicrogridId
@@ -41,7 +44,7 @@ DEFAULT_GRPC_CALL_TIMEOUT = 60.0
 
 
 class AssetsApiClient(
-    BaseApiClient[assets_pb2_grpc.PlatformAssetsStub]
+    BaseApiClient[platformassets_pb2_grpc.PlatformAssetsServiceStub]
 ):  # pylint: disable=too-many-arguments
     """A client for the Assets API."""
 
@@ -75,7 +78,7 @@ class AssetsApiClient(
         """
         super().__init__(
             server_url,
-            assets_pb2_grpc.PlatformAssetsStub,
+            platformassets_pb2_grpc.PlatformAssetsServiceStub,
             connect=connect,
             channel_defaults=channel_defaults,
             auth_key=auth_key,
@@ -83,7 +86,7 @@ class AssetsApiClient(
         )
 
     @property
-    def stub(self) -> assets_pb2_grpc.PlatformAssetsAsyncStub:
+    def stub(self) -> platformassets_pb2_grpc.PlatformAssetsServiceAsyncStub:
         """
         The gRPC stub for the Assets API.
 
@@ -127,7 +130,7 @@ class AssetsApiClient(
         response = await call_stub_method(
             self,
             lambda: self.stub.GetMicrogrid(
-                assets_pb2.GetMicrogridRequest(microgrid_id=int(microgrid_id)),
+                platformassets_pb2.GetMicrogridRequest(microgrid_id=int(microgrid_id)),
                 timeout=DEFAULT_GRPC_CALL_TIMEOUT,
             ),
             method_name="GetMicrogrid",
@@ -179,7 +182,7 @@ class AssetsApiClient(
         response = await call_stub_method(
             self,
             lambda: self.stub.ListMicrogridElectricalComponents(
-                assets_pb2.ListMicrogridElectricalComponentsRequest(
+                platformassets_pb2.ListMicrogridElectricalComponentsRequest(
                     microgrid_id=int(microgrid_id),
                 ),
                 timeout=DEFAULT_GRPC_CALL_TIMEOUT,
@@ -251,11 +254,14 @@ class AssetsApiClient(
                 issues are found. All exceptions in the group are
                 [InvalidConnectionError][frequenz.client.assets.exceptions.InvalidConnectionError].
         """
-        request = assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
+        source_ids = [int(c) for c in source_component_ids]
+        destination_ids = [int(c) for c in destination_component_ids]
+        request = platformassets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
             microgrid_id=int(microgrid_id),
-            source_component_ids=(int(c) for c in source_component_ids),
-            destination_component_ids=(int(c) for c in destination_component_ids),
         )
+        if source_ids or destination_ids:
+            request.filter.source_component_ids.extend(source_ids)
+            request.filter.destination_component_ids.extend(destination_ids)
 
         response = await call_stub_method(
             self,

--- a/tests/client_test_cases/get_microgrid/defaults_case.py
+++ b/tests/client_test_cases/get_microgrid/defaults_case.py
@@ -7,8 +7,8 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
 
-from frequenz.api.assets.v1 import assets_pb2
 from frequenz.api.common.v1alpha8.microgrid import microgrid_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from frequenz.client.common.microgrid import EnterpriseId, MicrogridId
 
 from frequenz.client.assets import Microgrid, MicrogridStatus

--- a/tests/client_test_cases/get_microgrid/error_case.py
+++ b/tests/client_test_cases/get_microgrid/error_case.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from grpc import StatusCode
 
 from frequenz.client.assets.exceptions import PermissionDenied

--- a/tests/client_test_cases/get_microgrid/full_case.py
+++ b/tests/client_test_cases/get_microgrid/full_case.py
@@ -8,10 +8,10 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from frequenz.api.assets.v1 import assets_pb2
 from frequenz.api.common.v1alpha8.grid import delivery_area_pb2
 from frequenz.api.common.v1alpha8.microgrid import microgrid_pb2
 from frequenz.api.common.v1alpha8.types import location_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from frequenz.client.base.conversion import to_timestamp
 from frequenz.client.common.microgrid import EnterpriseId, MicrogridId
 

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/empty_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/empty_case.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 
 # No client_args or client_kwargs needed for this call
 
@@ -14,7 +14,7 @@ def assert_stub_method_call(stub_method: Any) -> None:
     """Assert that the gRPC request matches the expected request."""
     stub_method.assert_called_once_with(
         assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
-            microgrid_id=1234, source_component_ids=[], destination_component_ids=[]
+            microgrid_id=1234
         ),
         timeout=60.0,
     )

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/error_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/error_case.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from grpc import StatusCode
 
 from frequenz.client.assets.exceptions import PermissionDenied

--- a/tests/client_test_cases/list_microgrid_electrical_component_connections/success_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_component_connections/success_case.py
@@ -6,11 +6,11 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
 from frequenz.api.common.v1alpha8.microgrid import lifetime_pb2
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
 )
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from frequenz.client.base.conversion import to_timestamp
 from frequenz.client.common.microgrid.electrical_components import ElectricalComponentId
 
@@ -22,7 +22,7 @@ def assert_stub_method_call(stub_method: Any) -> None:
     """Assert that the gRPC request matches the expected request."""
     stub_method.assert_called_once_with(
         assets_pb2.ListMicrogridElectricalComponentConnectionsRequest(
-            microgrid_id=1234, source_component_ids=[], destination_component_ids=[]
+            microgrid_id=1234
         ),
         timeout=60.0,
     )

--- a/tests/client_test_cases/list_microgrid_electrical_components/empty_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_components/empty_case.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 
 
 def assert_stub_method_call(stub_method: Any) -> None:

--- a/tests/client_test_cases/list_microgrid_electrical_components/error_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_components/error_case.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from grpc import StatusCode
 
 from frequenz.client.assets.exceptions import PermissionDenied

--- a/tests/client_test_cases/list_microgrid_electrical_components/success_case.py
+++ b/tests/client_test_cases/list_microgrid_electrical_components/success_case.py
@@ -5,10 +5,10 @@
 
 from typing import Any
 
-from frequenz.api.assets.v1 import assets_pb2
 from frequenz.api.common.v1alpha8.microgrid.electrical_components import (
     electrical_components_pb2,
 )
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2 as assets_pb2
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.electrical_components import ElectricalComponentId
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
-from frequenz.api.assets.v1 import assets_pb2_grpc
+from frequenz.api.platformassets.v1alpha1 import platformassets_pb2_grpc
 
 from frequenz.client.assets import AssetsApiClient
 
@@ -21,7 +21,9 @@ TESTS_DIR = Path(__file__).parent / "client_test_cases"
 @pytest.fixture
 async def client() -> AsyncIterator[AssetsApiClient]:
     """Fixture that provides a AssetsApiClient with a mock gRPC stub and channel."""
-    with patch_client_class(AssetsApiClient, assets_pb2_grpc.PlatformAssetsStub):
+    with patch_client_class(
+        AssetsApiClient, platformassets_pb2_grpc.PlatformAssetsServiceStub
+    ):
         client = AssetsApiClient("grpc://localhost:1234")
         async with client:
             yield client


### PR DESCRIPTION
## Summary
- bump frequenz-api-assets to 0.3.0
- migrate client imports from assets.v1 to platformassets.v1alpha1
- update request/test fixtures for the PlatformAssetsService API

## Validation
- .venv/bin/python -m pytest tests/test_client.py