### PR TITLE
Update to api-assets v0.4.0 / api-common v0.8.11

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,7 @@
 # Frequenz Assets API Client Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Bumped `frequenz-api-common` from `v0.8.9` to `v0.8.11` and `frequenz-api-assets` from `v0.3.0` to `v0.4.0`.
+- Renamed `MarketLocation` to `MarketLocationRef` to match the upstream protobuf rename in `frequenz-api-common` v0.8.11. The `market_location_from_proto` helper was renamed to `market_location_ref_from_proto` accordingly.
+- Renamed the `MarketTopologyRelation.market_location` field to `market_location_ref` to match the upstream protobuf field rename in `frequenz-api-assets` v0.4.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.13.0, < 5",
-  "frequenz-api-assets >= 0.3.0, < 0.4.0",
-  "frequenz-api-common >= 0.8.9, < 1",
+  "frequenz-api-assets >= 0.4.0, < 0.5.0",
+  "frequenz-api-common >= 0.8.11, < 1",
   "frequenz-client-base >= 0.11.0, < 0.12.0",
   "frequenz-client-common >= 0.3.8, < 0.5.0",
-  "grpcio >= 1.81.0, < 2",
+  "grpcio >= 1.81.1, < 2",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/client/assets/__init__.py
+++ b/src/frequenz/client/assets/__init__.py
@@ -16,7 +16,7 @@ from ._gridpool_energy_schedule import (
 from ._interval import Interval
 from ._lifetime import Lifetime
 from ._location import Location
-from ._market_location import MarketLocation, MarketLocationId, MarketLocationIdType
+from ._market_location import MarketLocationId, MarketLocationIdType, MarketLocationRef
 from ._market_topology import (
     MarketParticipation,
     MarketParticipationType,
@@ -40,9 +40,9 @@ __all__ = [
     "MicrogridStatus",
     "Location",
     "Lifetime",
-    "MarketLocation",
     "MarketLocationId",
     "MarketLocationIdType",
+    "MarketLocationRef",
     "MarketParticipation",
     "MarketParticipationType",
     "MarketTopologyRelation",

--- a/src/frequenz/client/assets/_market_location.py
+++ b/src/frequenz/client/assets/_market_location.py
@@ -68,8 +68,8 @@ class MarketLocationId:
 
 
 @dataclass(frozen=True, kw_only=True)
-class MarketLocation:
-    """A market-facing metering point in a specific market area."""
+class MarketLocationRef:
+    """A reference to a market-facing metering point in a specific market area."""
 
     market_area: int
     """The market area in which this market location is registered."""

--- a/src/frequenz/client/assets/_market_location_proto.py
+++ b/src/frequenz/client/assets/_market_location_proto.py
@@ -1,12 +1,12 @@
 # License: MIT
 # Copyright © 2026 Frequenz Energy-as-a-Service GmbH
 
-"""Conversion of MarketLocation objects to/from protobuf messages."""
+"""Conversion of MarketLocationRef objects to/from protobuf messages."""
 
 from frequenz.api.common.v1alpha8.grid import market_location_pb2
 from frequenz.client.common.proto import enum_from_proto
 
-from ._market_location import MarketLocation, MarketLocationId, MarketLocationIdType
+from ._market_location import MarketLocationId, MarketLocationIdType, MarketLocationRef
 
 
 def market_location_id_from_proto(
@@ -19,11 +19,11 @@ def market_location_id_from_proto(
     )
 
 
-def market_location_from_proto(
-    message: market_location_pb2.MarketLocation,
-) -> MarketLocation:
-    """Convert a protobuf market location message to a domain object."""
-    return MarketLocation(
+def market_location_ref_from_proto(
+    message: market_location_pb2.MarketLocationRef,
+) -> MarketLocationRef:
+    """Convert a protobuf market location ref message to a domain object."""
+    return MarketLocationRef(
         market_area=message.market_area,
         market_location_id=(
             market_location_id_from_proto(message.market_location_id)

--- a/src/frequenz/client/assets/_market_topology.py
+++ b/src/frequenz/client/assets/_market_topology.py
@@ -11,7 +11,7 @@ from frequenz.client.common.microgrid import MicrogridId
 
 from ._delivery_area import DeliveryArea
 from ._interval import Interval
-from ._market_location import MarketLocation
+from ._market_location import MarketLocationRef
 
 
 @enum.unique
@@ -46,7 +46,7 @@ class MarketTopologyRelation:
     microgrid_id: MicrogridId | None
     """The microgrid associated with this relation."""
 
-    market_location: MarketLocation | None
+    market_location_ref: MarketLocationRef | None
     """The market location associated with this relation."""
 
     gridpool_id: int | None

--- a/src/frequenz/client/assets/_market_topology_proto.py
+++ b/src/frequenz/client/assets/_market_topology_proto.py
@@ -9,7 +9,7 @@ from frequenz.client.common.proto import enum_from_proto
 
 from ._delivery_area_proto import delivery_area_from_proto
 from ._interval_proto import interval_from_proto
-from ._market_location_proto import market_location_from_proto
+from ._market_location_proto import market_location_ref_from_proto
 from ._market_topology import (
     MarketParticipation,
     MarketParticipationType,
@@ -41,9 +41,9 @@ def market_topology_relation_from_proto(
             if message.HasField("microgrid_id")
             else None
         ),
-        market_location=(
-            market_location_from_proto(message.market_location)
-            if message.HasField("market_location")
+        market_location_ref=(
+            market_location_ref_from_proto(message.market_location_ref)
+            if message.HasField("market_location_ref")
             else None
         ),
         gridpool_id=message.gridpool_id if message.HasField("gridpool_id") else None,

--- a/tests/client_test_cases/list_market_topology_relations/success_case.py
+++ b/tests/client_test_cases/list_market_topology_relations/success_case.py
@@ -17,9 +17,9 @@ from frequenz.client.assets import (
     DeliveryArea,
     EnergyMarketCodeType,
     Interval,
-    MarketLocation,
     MarketLocationId,
     MarketLocationIdType,
+    MarketLocationRef,
     MarketParticipation,
     MarketParticipationType,
     MarketTopologyRelation,
@@ -64,7 +64,7 @@ grpc_response = assets_pb2.ListMarketTopologyRelationsResponse(
     relations=[
         assets_pb2.MarketTopologyRelation(
             microgrid_id=1234,
-            market_location=market_location_pb2.MarketLocation(
+            market_location_ref=market_location_pb2.MarketLocationRef(
                 market_area=market_area_pb2.MarketArea.ValueType(1),
                 market_location_id=market_location_pb2.MarketLocationId(
                     id=market_location_pb2.MarketLocationIdValue(value="DE001"),
@@ -94,7 +94,7 @@ def assert_client_result(result: Any) -> None:
     assert result == [
         MarketTopologyRelation(
             microgrid_id=MicrogridId(1234),
-            market_location=MarketLocation(
+            market_location_ref=MarketLocationRef(
                 market_area=1,
                 market_location_id=MarketLocationId(
                     value="DE001", type=MarketLocationIdType.MALO_ID


### PR DESCRIPTION
The common API renamed and moved `market.MarketLocation` to `grip.MarketLocationRef` between v0.8.9 and v0.8.11. The assets API update the common API dependency in v0.4.0.

This commit bring the client up to date with those changes, renaming the `MarketLocation` wrapper to `MarketLocationRef` to match the upstream changes.
